### PR TITLE
내장 톰캣으로 테스트

### DIFF
--- a/Chapter02/src/test/java/com/example/BoardControllerTest.java
+++ b/Chapter02/src/test/java/com/example/BoardControllerTest.java
@@ -1,27 +1,30 @@
 package com.example;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.boot.test.web.client.TestRestTemplate;
 
-@SpringBootTest(webEnvironment=WebEnvironment.MOCK)
-@AutoConfigureMockMvc
+import com.example.domain.BoardVO;
+
+@SpringBootTest(webEnvironment=WebEnvironment.RANDOM_PORT)
 public class BoardControllerTest {
 	
 	@Autowired
-	private MockMvc mockMvc;
+	private TestRestTemplate restTemplate;
 	
 	@Test
 	public void testHello() throws Exception{
-		mockMvc.perform(get("/hello").param("name", "둘리"))
-		.andExpect(status().isOk())
-		.andDo(print());
+		String result = restTemplate.getForObject("/hello?name=둘리", String.class);
+		assertEquals("Hello : 둘리", result);
+	}
+	
+	@Test
+	public void testGetBoard() throws Exception{
+		BoardVO board = restTemplate.getForObject("/getBoard", BoardVO.class);
+		assertEquals("테스터", board.getWriter());
 	}
 }


### PR DESCRIPTION
MOCK : 모킹된 서블릿 컨테이너를 제공하기 때문에 내장 톰캣이 구동되지 않는다
RANDOM_PORT : 랜덤한 포트로 내장 톰캣을 구동하여 서블릿 컨테이너를 초기화
DERINED_PORT : application.properties 파일에 설정된 서버 포트로 내장 톰캣을 구동하여 서블릿
컨테이너를 초기화
NONE : 서블릿 기반의 환경 자체를 구성하지 않는다

@SpringBootTest(webEnvironment=WebEnvironment.RANDOM_PORT)를 사용하면 내장톰캣으로
테스트를 할 수 있다
MockMvc 객체 대신 TestRestTemplate 객체를 주입해 컨트롤러를 요청