### PR TITLE
스프링과 JPA

### DIFF
--- a/Chapter04/pom.xml
+++ b/Chapter04/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example</groupId>
+  <artifactId>Chapter04</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <name>Chapter04</name>
+  <!-- FIXME change it to the project's website -->
+  <url>http://www.example.com</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-entitymanager</artifactId>
+      <version>5.1.0.Final</version>
+    </dependency>
+    
+    <dependency>
+    	<groupId>com.h2database</groupId>
+    	<artifactId>h2</artifactId>
+    	<version>1.4.197</version>
+    </dependency>
+    
+  </dependencies>
+
+  <build>
+    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+      <plugins>
+        <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+        <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.7.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/Chapter04/src/main/java/META-INF/persistence.xml
+++ b/Chapter04/src/main/java/META-INF/persistence.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.1" xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
+	
+	<persistence-unit name="Chapter04">
+		<class>com.example.domain.Board</class>
+		<properties>
+			<property name="javax.persistence.jdbc.driver" value="org.h2.Driver"/>
+			<property name="javax.persistence.jdbc.user" value="sa"/>
+			<property name="javax.persistence.jdbc.password" value=""/>
+			<property name="javax.persistence.jdbc.url" value="jdbc:h2:~/test"/>
+			<property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+			
+			<property name="hibernate.show_sql" value="true"/>
+			<property name="hibernate.format_sql" value="true"/>
+			<property name="hibernate.use_sql_comments" value="false"/>
+			<property name="hibernate.id.new_generator_mappings" value="true"/>
+			<property name="hibernate.hbm2ddl.auto" value="create"/>
+		</properties>
+	</persistence-unit>
+	
+</persistence>

--- a/Chapter04/src/main/java/com/example/App.java
+++ b/Chapter04/src/main/java/com/example/App.java
@@ -1,0 +1,13 @@
+package com.example;
+
+/**
+ * Hello world!
+ *
+ */
+public class App 
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Hello World!" );
+    }
+}

--- a/Chapter04/src/main/java/com/example/JPAClient.java
+++ b/Chapter04/src/main/java/com/example/JPAClient.java
@@ -1,0 +1,34 @@
+package com.example;
+
+import java.util.Date;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+import com.example.domain.Board;
+
+public class JPAClient {
+
+	public static void main(String[] args) {
+		EntityManagerFactory emf = Persistence.createEntityManagerFactory("Chapter04");
+		EntityManager em = emf.createEntityManager();
+		try {
+			Board board = new Board();
+			board.setTitle("JPA 제목");
+			board.setWrite("관리자");
+			board.setContent("JPA 글 등록 잘 되네요.");
+			board.setCreateDate(new Date());
+			board.setCng(0L);
+			
+			em.persist(board);
+		}catch(Exception e) {
+			e.printStackTrace();
+		}finally {
+			em.close();
+			emf.close();
+		}
+
+	}
+
+}

--- a/Chapter04/src/main/java/com/example/domain/Board.java
+++ b/Chapter04/src/main/java/com/example/domain/Board.java
@@ -1,0 +1,69 @@
+package com.example.domain;
+
+import java.util.Date;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * Entity implementation class for Entity: Board
+ *
+ */
+@Entity
+@Table(name = "BOARD")
+public class Board{
+	@Id
+	@GeneratedValue
+	private Long seq;
+	private String title;
+	private String write;
+	private String content;
+	private Date createDate;
+	private Long cng;
+	
+	public Long getSeq() {
+		return seq;
+	}
+	public void setSeq(Long seq) {
+		this.seq = seq;
+	}
+	public String getTitle() {
+		return title;
+	}
+	public void setTitle(String title) {
+		this.title = title;
+	}
+	public String getWrite() {
+		return write;
+	}
+	public void setWrite(String write) {
+		this.write = write;
+	}
+	public String getContent() {
+		return content;
+	}
+	public void setContent(String content) {
+		this.content = content;
+	}
+	public Date getCreateDate() {
+		return createDate;
+	}
+	public void setCreateDate(Date createDate) {
+		this.createDate = createDate;
+	}
+	public Long getCng() {
+		return cng;
+	}
+	public void setCng(Long cng) {
+		this.cng = cng;
+	}
+	
+	@Override
+	public String toString() {
+		return "Board [seq=" + seq + ", title=" + title + ", write=" + write + ", content=" + content + ", createDate="
+				+ createDate + ", cng=" + cng + "]";
+	}
+	
+}

--- a/Chapter04/src/test/java/com/example/AppTest.java
+++ b/Chapter04/src/test/java/com/example/AppTest.java
@@ -1,0 +1,20 @@
+package com.example;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest 
+{
+    /**
+     * Rigorous Test :-)
+     */
+    @Test
+    public void shouldAnswerWithTrue()
+    {
+        assertTrue( true );
+    }
+}


### PR DESCRIPTION
하이버네이트 같은 ORM은 애플리케이션에서 사용하는 SQL까지도 프레임워크에서 제공하기 때문에 개발자가 처리해야 할 일들을
엄청나게 줄여준다.
ORM들을 보다 쉽게 사용할 수 있도록 표준화시킨 것이 JPA이다.

JPA는 자바 애플리케이션과 JDBC 사이에 존재하면서 JDBC의 복잡한 절차를 대신 처리해준다.
JPA는 데이터베이스 연동에 사용되는 코드뿐만 아니라 SQL까지 제공한다는 것이다.

테이블과 VO클래스의 이름을 똑같이 매핑하고, 테이블의 컬럼을 VO클래스의 멤버 변수와 매핑한다.
테이블과 매핑되는 자바 클래스를 엔티티라고 한다.